### PR TITLE
Open tabs next to the current one

### DIFF
--- a/chrome/src/bg/background.js
+++ b/chrome/src/bg/background.js
@@ -12,7 +12,19 @@ request.onload = function() {
   chrome.extension.onMessage.addListener(
     function(request, sender, sendMessage) {
       if(request.url) {
-        chrome.tabs.create(request)
+        chrome.tabs.query(
+          {windowId: sender.tab.windowId},
+          function(tabs) {
+            var position = sender.tab.index;
+            for(var i = position; i < tabs.length; i++) {
+              if(tabs[i].openerTabId == sender.tab.id) {
+                position = i
+              }
+            }
+            request.openerTabId = sender.tab.id
+            request.index = position + 1
+            chrome.tabs.create(request)
+          })
       } else {
         sendMessage(data)
       }


### PR DESCRIPTION
When clicking or cmd-clicking a link in a tab, Chrome opens a new tab next to the current one, or, if many have been clicked, at the end of that "local stack". `chrome.tabs.create` opens new tabs in the last position in the window by default, so update the code to mirror the mouse-click behavior.