### PR TITLE
first crack at adding a quick unwatch repo button

### DIFF
--- a/chrome/js/unwatch.js
+++ b/chrome/js/unwatch.js
@@ -1,4 +1,0 @@
-form = $('form[action=\"/notifications/subscribe\"]');
-$(form).find('#do_included').attr('checked', true);
-$(form).find('#do_included').removeAttr('checked');
-$(form).submit();

--- a/chrome/js/unwatch.js
+++ b/chrome/js/unwatch.js
@@ -1,0 +1,4 @@
+form = $('form[action=\"/notifications/subscribe\"]');
+$(form).find('#do_included').attr('checked', true);
+$(form).find('#do_included').removeAttr('checked');
+$(form).submit();

--- a/chrome/manifest.json
+++ b/chrome/manifest.json
@@ -5,9 +5,6 @@
   "manifest_version": 2,
   "description": "Add links to GitHub threads and shortcuts to your Gmail interface.",
   "homepage_url": "http://github.com/muan/github-gmail",
-  "permissions": [
-    "tabs", "https://github.com/"
-  ],
   "icons": {
     "16": "images/icon16.png",
     "48": "images/icon48.png",
@@ -37,7 +34,6 @@
       ],
       "js": [
         "js/jquery.js",
-        "js/unwatch.js",
         "src/inject/inject.js"
       ]
     }

--- a/chrome/manifest.json
+++ b/chrome/manifest.json
@@ -5,6 +5,9 @@
   "manifest_version": 2,
   "description": "Add links to GitHub threads and shortcuts to your Gmail interface.",
   "homepage_url": "http://github.com/muan/github-gmail",
+  "permissions": [
+    "tabs", "https://github.com/"
+  ],
   "icons": {
     "16": "images/icon16.png",
     "48": "images/icon48.png",
@@ -34,6 +37,7 @@
       ],
       "js": [
         "js/jquery.js",
+        "js/unwatch.js",
         "src/inject/inject.js"
       ]
     }

--- a/chrome/src/bg/background.js
+++ b/chrome/src/bg/background.js
@@ -36,7 +36,11 @@ request.onload = function() {
     // avoid conflict with other listner
     if(request.unwatchUrl) {
         chrome.tabs.create({url: request.unwatchUrl, active: false}, function(tab) {
-          setTimeout(function() { chrome.tabs.remove(tab.id) }, 1500);
+          chrome.tabs.executeScript(tab.id, {file: 'js/jquery.js'}, function() {
+            chrome.tabs.executeScript(tab.id, {file: 'js/unwatch.js'}, function() {
+              chrome.tabs.remove(tab.id)
+            })
+          })
         })
       }
     }

--- a/chrome/src/bg/background.js
+++ b/chrome/src/bg/background.js
@@ -36,11 +36,7 @@ request.onload = function() {
     // avoid conflict with other listner
     if(request.unwatchUrl) {
         chrome.tabs.create({url: request.unwatchUrl, active: false}, function(tab) {
-          chrome.tabs.executeScript(tab.id, {file: 'js/jquery.js'}, function() {
-            chrome.tabs.executeScript(tab.id, {file: 'js/unwatch.js'}, function() {
-              chrome.tabs.remove(tab.id)
-            })
-          })
+          setTimeout(function() { chrome.tabs.remove(tab.id) }, 1500);
         })
       }
     }

--- a/chrome/src/bg/background.js
+++ b/chrome/src/bg/background.js
@@ -30,4 +30,20 @@ request.onload = function() {
       }
     }
   )
+
+  chrome.runtime.onMessage.addListener(
+  function(request, sender, sendResponse) {
+    // avoid conflict with other listner
+    if(request.unwatchUrl) {
+        chrome.tabs.create({url: request.unwatchUrl, active: false}, function(tab) {
+          chrome.tabs.executeScript(tab.id, {file: 'js/jquery.js'}, function() {
+            chrome.tabs.executeScript(tab.id, {file: 'js/unwatch.js'}, function() {
+              chrome.tabs.remove(tab.id)
+            })
+          })
+        })
+      }
+    }
+  )
+
 }

--- a/chrome/src/inject/inject.js
+++ b/chrome/src/inject/inject.js
@@ -49,6 +49,18 @@ function initOnHashChangeAction(domains) {
           link = $("<a class='github-link T-I J-J5-Ji lS T-I-ax7 ar7' target='_blank' href='"+ url +"'>Visit Thread on GitHub</a>")
 
           $(".iH > div").append(link)
+
+          // automatic subscription email
+          if( $(mail_body).find(':contains("automatically subscribed")').length) {
+            link = $("<a class='github-link T-I J-J5-Ji lS T-I-ax7 ar7' href='#'>Unwatch on GitHub</a>")
+            $(".iH > div").append(link)
+
+            link.on('click', function() {
+              // opens a new tab and unwatches the repo
+              chrome.runtime.sendMessage({unwatchUrl: url}, function(response){})
+            })
+          }
+
           window.idled = true
 
           document.getElementsByClassName('github-link')[0].addEventListener("DOMNodeRemovedFromDocument", function (ev) {

--- a/chrome/src/inject/inject.js
+++ b/chrome/src/inject/inject.js
@@ -35,8 +35,8 @@ function initOnHashChangeAction(domains) {
 
       if( mail_body ) {
 
-        github_links = mail_body.querySelectorAll(selectors)
-        github_links = reject_unwanted_paths(github_links)
+        all_github_links = mail_body.querySelectorAll(selectors)
+        github_links = reject_unwanted_paths(all_github_links)
 
         // Avoid multple buttons
         $('.github-link').remove()
@@ -52,6 +52,8 @@ function initOnHashChangeAction(domains) {
 
           // automatic subscription email
           if( $(mail_body).find(':contains("automatically subscribed")').length) {
+            url = get_unsubscribe_path(all_github_links)[0].href
+
             link = $("<a class='github-link T-I J-J5-Ji lS T-I-ax7 ar7' href='#'>Unwatch on GitHub</a>")
             $(".iH > div").append(link)
 
@@ -221,5 +223,11 @@ function reject_unwanted_paths (links) {
   regexp = new RegExp(paths.join('|'))
   return $(links).filter(function() {
     if(!this.href.match(regexp)) return this
+  })
+}
+
+function get_unsubscribe_path(links) {
+  return $(links).filter(function() {
+    if( this.href.search('unsubscribe_via_email') != -1 ) return this
   })
 }

--- a/chrome/src/inject/inject.js
+++ b/chrome/src/inject/inject.js
@@ -35,8 +35,8 @@ function initOnHashChangeAction(domains) {
 
       if( mail_body ) {
 
-        all_github_links = mail_body.querySelectorAll(selectors)
-        github_links = reject_unwanted_paths(all_github_links)
+        github_links = mail_body.querySelectorAll(selectors)
+        github_links = reject_unwanted_paths(github_links)
 
         // Avoid multple buttons
         $('.github-link').remove()
@@ -52,8 +52,6 @@ function initOnHashChangeAction(domains) {
 
           // automatic subscription email
           if( $(mail_body).find(':contains("automatically subscribed")').length) {
-            url = get_unsubscribe_path(all_github_links)[0].href
-
             link = $("<a class='github-link T-I J-J5-Ji lS T-I-ax7 ar7' href='#'>Unwatch on GitHub</a>")
             $(".iH > div").append(link)
 
@@ -223,11 +221,5 @@ function reject_unwanted_paths (links) {
   regexp = new RegExp(paths.join('|'))
   return $(links).filter(function() {
     if(!this.href.match(regexp)) return this
-  })
-}
-
-function get_unsubscribe_path(links) {
-  return $(links).filter(function() {
-    if( this.href.search('unsubscribe_via_email') != -1 ) return this
   })
 }


### PR DESCRIPTION
I get automatically subscribed to new repos a lot from work and I usually just unwatch them unless its close to an area I'm working on. Yesterday I played around with adding another button which is a one click unwatch without leaving my gmail inbox.

@muan what do you think - is this something you would consider incorporating into the extension? Let me know if you think so and I'll put some more work into cleaning it up a bit. :rocket: 