### PR TITLE
Fix mute button and clean github-link URL 

### DIFF
--- a/chrome/src/bg/background.js
+++ b/chrome/src/bg/background.js
@@ -23,11 +23,25 @@ request.onload = function() {
             }
             request.openerTabId = sender.tab.id
             request.index = position + 1
-            chrome.tabs.create(request)
-          })
+            chrome.tabs.create(request, function(tab) { listenAndCloseTab(tab, request.url, sender.tab.id) })
+          }
+        )
       } else {
         sendMessage(data)
       }
     }
   )
+}
+
+function listenAndCloseTab (tab, url, originalTabId) {
+  var listener = setInterval(function () {
+    chrome.tabs.get(tab.id, function (tab) {
+      if (tab.status === 'complete') {
+        chrome.tabs.remove(tab.id)
+        clearInterval(listener)
+        // Unsubscription finished
+        chrome.tabs.sendMessage(originalTabId, {muteURL: url})
+      }
+    })
+  }, 500)
 }

--- a/chrome/src/bg/background.js
+++ b/chrome/src/bg/background.js
@@ -9,28 +9,31 @@ request.onload = function() {
     if(localStorage[key]) { data[key] = localStorage[key] }
   }
 
-  chrome.extension.onMessage.addListener(
-    function(request, sender, sendMessage) {
-      if(request.url) {
-        chrome.tabs.query(
-          {windowId: sender.tab.windowId},
-          function(tabs) {
-            var position = sender.tab.index;
-            for(var i = position; i < tabs.length; i++) {
-              if(tabs[i].openerTabId == sender.tab.id) {
-                position = i
-              }
+  chrome.extension.onMessage.addListener(function(req, sender, sendMessage) {
+    if(req.url) {
+      chrome.tabs.query(
+        {windowId: sender.tab.windowId},
+        function(tabs) {
+          var position = sender.tab.index;
+          for(var i = position; i < tabs.length; i++) {
+            if(tabs[i].openerTabId == sender.tab.id) {
+              position = i
             }
-            request.openerTabId = sender.tab.id
-            request.index = position + 1
-            chrome.tabs.create(request, function(tab) { listenAndCloseTab(tab, request.url, sender.tab.id) })
           }
-        )
-      } else {
-        sendMessage(data)
-      }
+          var mute = req.mute
+          delete req.mute
+
+          req.openerTabId = sender.tab.id
+          req.index = position + 1
+          chrome.tabs.create(req, function(tab) {
+            if (mute) listenAndCloseTab(tab, req.url, sender.tab.id)
+          })
+        }
+      )
+    } else {
+      sendMessage(data)
     }
-  )
+  })
 }
 
 function listenAndCloseTab (tab, url, originalTabId) {

--- a/chrome/src/inject/inject.css
+++ b/chrome/src/inject/inject.css
@@ -1,7 +1,9 @@
-.github-link {
+.github-link,
+.github-mute {
   text-decoration: none;
   cursor: pointer;
 }
-.github-link:hover {
+.github-link:hover,
+.github-mute:hover {
   border-color: rgba(0,0,0,0.2) !important;
 }

--- a/chrome/src/inject/inject.js
+++ b/chrome/src/inject/inject.js
@@ -16,7 +16,7 @@ function initOnHashChangeAction(domains) {
   if(domains) allDomains += domains
 
   // Take string -> make array -> make queries -> avoid nil -> join queries to string
-  var selectors = allDomains.replace(/\s/, '').split(',').map(function (name) {
+  var selectors = allDomains.replace(/\s/g, '').split(',').map(function (name) {
     if (name.length) return (".AO [href*='" + name + "']")
   }).filter(function (name) { return name }).join(", ")
 
@@ -63,8 +63,8 @@ function initOnHashChangeAction(domains) {
             })
           }
 
-          // Go to thread instead of .diff link (pull request notifications)
-          url = url.match(/\.diff/) ? url.slice(0, url.length-5) : url
+          // Go to thread instead of diffs or file views
+          url = url.match(/^(.+\/\d+)/)[1]
           var link = document.createElement('a')
           link.href = url
           link.className = 'github-link T-I J-J5-Ji lS T-I-ax7 ar7'

--- a/chrome/src/inject/inject.js
+++ b/chrome/src/inject/inject.js
@@ -65,7 +65,7 @@ function initOnHashChangeAction(domains) {
 
             muteLink.addEventListener('click', function (evt) {
               evt.preventDefault()
-              chrome.extension.sendMessage({url: muteURL, active: false})
+              chrome.extension.sendMessage({url: muteURL, active: false, mute: true})
               muteLink.innerHTML = '&ctdot;'
             })
           }

--- a/chrome/src/inject/inject.js
+++ b/chrome/src/inject/inject.js
@@ -7,6 +7,14 @@ chrome.extension.sendMessage({}, function (settings) {
   initForInbox()
 })
 
+chrome.runtime.onMessage.addListener(function (req) {
+  var element = req['muteURL'] ? document.querySelector('[href="' + req['muteURL'] + '"]') : null
+
+  if (element) {
+    element.innerText = "Muted!"
+  }
+})
+
 function initForInbox() {
   window.idled = true
 }
@@ -38,7 +46,7 @@ function initOnHashChangeAction(domains) {
         var github_links = reject_unwanted_paths(mail_body.querySelectorAll(selectors))
 
         // Avoid multple buttons
-        Array.prototype.forEach.call(document.querySelectorAll('.github-link, .github-mute-button'), function (ele) {
+        Array.prototype.forEach.call(document.querySelectorAll('.github-link, .github-mute'), function (ele) {
           ele.remove()
         })
 
@@ -50,16 +58,15 @@ function initOnHashChangeAction(domains) {
           if (url.match('notifications/unsubscribe')) {
             var muteURL = url
             url = github_links[github_links.length-2].href
-            muteLink = document.createElement('button')
-            muteLink.type = 'button'
-            muteLink.className = 'github-mute-button T-I J-J5-Ji lS T-I-ax7 ar7'
+            muteLink = document.createElement('a')
+            muteLink.className = 'github-mute T-I J-J5-Ji lS T-I-ax7 ar7'
             muteLink.innerText = 'Mute thread'
-            muteLink.addEventListener('click', function () {
+            muteLink.href = muteURL
+
+            muteLink.addEventListener('click', function (evt) {
+              evt.preventDefault()
+              chrome.extension.sendMessage({url: muteURL, active: false})
               muteLink.innerHTML = '&ctdot;'
-              fetch(muteURL, {mode: 'no-cors'}).then(function () {
-                muteLink.innerText = 'Muted!'
-                muteLink.disabled = 'disabled'
-              })
             })
           }
 
@@ -116,8 +123,8 @@ function initShortcuts(shortcut, backgroundShortcut, muteShortcut) {
     }
 
     // Mute Shortcut: bind user's combination, if a button exist and event not in a textarea
-    if (processRightCombinationBasedOnShortcut(muteShortcut, event) && window.idled && getVisible(document.getElementsByClassName('github-mute-button')) && notAnInput(event.target)) {
-      getVisible(document.getElementsByClassName('github-mute-button')).click()
+    if (processRightCombinationBasedOnShortcut(muteShortcut, event) && window.idled && getVisible(document.getElementsByClassName('github-mute')) && notAnInput(event.target)) {
+      getVisible(document.getElementsByClassName('github-mute')).click()
     }
   })
 }

--- a/chrome/src/inject/inject.js
+++ b/chrome/src/inject/inject.js
@@ -71,7 +71,7 @@ function initOnHashChangeAction(domains) {
           }
 
           // Go to thread instead of diffs or file views
-          url = url.match(/^(.+\/\d+)/)[1]
+          if (url.match(/^(.+\/(issue|pull)\/\d+)/)) url = url.match(/^(.+\/(issue|pull)\/\d+)/)[1]
           var link = document.createElement('a')
           link.href = url
           link.className = 'github-link T-I J-J5-Ji lS T-I-ax7 ar7'


### PR DESCRIPTION
Closes #60. This does 2 things:

1. It cleans "view thread" URL so we always open the "Conversation" tab and not file/commit/diff view
2. Fix mute button: This now works a little bit differently than before. The button will open a background tab in Chrome and wait for it to finish loading (auth -> redirect), then close the tab. 

![](https://cl.ly/25251m18420i/Screen%20Recording%202017-02-09%20at%2003.15%20PM.gif)

