### PR TITLE
Fix links so they are clickable

### DIFF
--- a/chrome/src/inject/inject.js
+++ b/chrome/src/inject/inject.js
@@ -62,6 +62,7 @@ function initOnHashChangeAction(domains) {
             muteLink.className = 'github-mute T-I J-J5-Ji lS T-I-ax7 ar7'
             muteLink.innerText = 'Mute thread'
             muteLink.href = muteURL
+            muteLink.style = "pointer-events: auto"
 
             muteLink.addEventListener('click', function (evt) {
               evt.preventDefault()
@@ -77,6 +78,7 @@ function initOnHashChangeAction(domains) {
           link.className = 'github-link T-I J-J5-Ji lS T-I-ax7 ar7'
           link.target = '_blank'
           link.innerText = 'View on GitHub'
+          link.style = "pointer-events: auto"
 
           document.querySelector('.iH > div').appendChild(link)
 

--- a/firefox/src/inject/inject.js
+++ b/firefox/src/inject/inject.js
@@ -59,6 +59,7 @@ function initOnHashChangeAction(domains) {
             muteLink.className = 'github-mute T-I J-J5-Ji lS T-I-ax7 ar7'
             muteLink.innerText = 'Mute thread'
             muteLink.href = muteURL
+            muteLink.style = "pointer-events: auto"
 
             muteLink.addEventListener('click', function (evt) {
               evt.preventDefault()
@@ -74,6 +75,7 @@ function initOnHashChangeAction(domains) {
           link.className = 'github-link T-I J-J5-Ji lS T-I-ax7 ar7'
           link.target = '_blank'
           link.innerText = 'View on GitHub'
+          link.style = "pointer-events: auto"
 
           document.querySelector('.iH > div').appendChild(link)
 


### PR DESCRIPTION
It appears as though the `ar7` class is now associated with another `ask` class in Gmail now. I don't really know if this was the case previously, but now there is a `pointer-events: none` in the css.

![image](https://user-images.githubusercontent.com/3364111/118303344-92786f00-b4a2-11eb-9756-c971e8c14b6b.png)

This leads to `pointer-events: none` being added to the `ar7` class making the links in Gmail no longer clickable. Since the `ar7` class is still used for color, font, and alignment, this overrides the `pointer-events` to `auto` in the link style. I'm not sure this is the nicest way to fix the problem, but it appears to work.